### PR TITLE
Added parity pmr types with enums

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/paritytrading/node-parity-pmr#readme
 // Definitions by: Leo Vujanić <https://github.com/leovujanic>
 
+import {Buffer} from "node";
 
 /**
  * Declares Parity PMR message structure

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,47 @@
 // Type definitions for parity-pmr 0.1
 // Project: https://github.com/paritytrading/node-parity-pmr#readme
 // Definitions by: Leo Vujanić <https://github.com/leovujanic>
-
+// Full protocol specification can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMR.md#readme
 import {Buffer} from "node";
 
-/**
- * Declares Parity PMR message structure
- * Full reference can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMR.md
- */
-export interface PMRMessage {
-    messageType: string;
-    version?: number;
-    timestamp?: number;
-    username?: string;
-    orderNumber?: string;
-    side?: string;
-    instrument?: string;
-    quantity?: number;
-    price?: number;
-    canceledQuantity?: number;
-    matchNumber?: number;
-    restingOrderNumber?: number;
-    incomingOrderNumber?: number;
+export interface Version {
+    messageType: "V",
+    version: number;
 }
 
-export function format(message: PMRMessage): Buffer;
+export interface OrderEntered {
+    messageType: "E",
+    timestamp: number;
+    username: string;
+    orderNumber: number;
+    side: "B" | "S";
+    instrument: string;
+    quantity: number;
+    price: number;
+}
 
-export function parse(buffer: Buffer): PMRMessage;
+export interface OrderAdded {
+    messageType: "A",
+    timestamp: number;
+    orderNumber: number;
+}
+
+export interface OrderCanceled {
+    messageType: "X",
+    timestamp: number;
+    orderNumber: number;
+    canceledQuantity: number;
+}
+
+export interface Trade {
+    messageType: "T",
+    timestamp: number;
+    restingOrderNumber: number;
+    incomingOrderNumber: number;
+    quantity: number;
+    matchNumber: number;
+}
+
+export function format(message: Version | OrderEntered | OrderAdded | OrderCanceled | Trade): Buffer;
+
+export function parse(buffer: Buffer): Version | OrderEntered | OrderAdded | OrderCanceled | Trade;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for parity-pmr 0.1
+// Project: https://github.com/paritytrading/node-parity-pmr#readme
+// Definitions by: Leo Vujanić <https://github.com/leovujanic>
+
+
+/**
+ * Declares Parity PMR message structure
+ * Full reference can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMR.md
+ */
+export interface PMRMessage {
+    messageType: string;
+    version?: number;
+    timestamp?: number;
+    username?: string;
+    orderNumber?: string;
+    side?: string;
+    instrument?: string;
+    quantity?: number;
+    price?: number;
+    canceledQuantity?: number;
+    matchNumber?: number;
+    restingOrderNumber?: number;
+    incomingOrderNumber?: number;
+}
+
+export function format(message: PMRMessage): Buffer;
+
+export function parse(buffer: Buffer): PMRMessage;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,37 +4,50 @@
 // Full protocol specification can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMR.md#readme
 import {Buffer} from "node";
 
+export enum MessageType {
+    ORDER_ADDED = "A",
+    ORDER_ENTERED = "E",
+    ORDER_CANCELED = "X",
+    VERSION = "V",
+    TRADE = "T",
+}
+
+export enum Side {
+    BUY = "B",
+    SELL = "S"
+}
+
 export interface Version {
-    messageType: "V",
+    messageType: MessageType.VERSION,
     version: number;
 }
 
 export interface OrderEntered {
-    messageType: "E",
+    messageType: MessageType.ORDER_ENTERED,
     timestamp: number;
     username: string;
     orderNumber: number;
-    side: "B" | "S";
+    side: Side;
     instrument: string;
     quantity: number;
     price: number;
 }
 
 export interface OrderAdded {
-    messageType: "A",
+    messageType: MessageType.ORDER_ADDED,
     timestamp: number;
     orderNumber: number;
 }
 
 export interface OrderCanceled {
-    messageType: "X",
+    messageType: MessageType.ORDER_CANCELED,
     timestamp: number;
     orderNumber: number;
     canceledQuantity: number;
 }
 
 export interface Trade {
-    messageType: "T",
+    messageType: MessageType.TRADE,
     timestamp: number;
     restingOrderNumber: number;
     incomingOrderNumber: number;

--- a/index.js
+++ b/index.js
@@ -1,165 +1,181 @@
 'use strict';
 
+const MessageType = {
+    ORDER_ADDED:  "A",
+    ORDER_ENTERED: "E",
+    ORDER_CANCELED: "X",
+    VERSION: "V",
+    TRADE: "T"
+};
+
+const Side = {
+    BUY: "B",
+    SELL: "S"
+};
+
+exports.Side = Side;
+exports.MessageType = MessageType;
+
 exports.format = (message) => {
-  switch (message.messageType) {
-    case 'V':
-      return formatVersion(message);
-    case 'E':
-      return formatOrderEntered(message);
-    case 'A':
-      return formatOrderAdded(message);
-    case 'X':
-      return formatOrderCanceled(message);
-    case 'T':
-      return formatTrade(message);
-    default:
-      throw new Error('Unknown message type: ' + message.messageType);
-  }
+    switch (message.messageType) {
+        case MessageType.VERSION:
+            return formatVersion(message);
+        case MessageType.ORDER_ENTERED:
+            return formatOrderEntered(message);
+        case MessageType.ORDER_ADDED:
+            return formatOrderAdded(message);
+        case MessageType.ORDER_CANCELED:
+            return formatOrderCanceled(message);
+        case MessageType.TRADE:
+            return formatTrade(message);
+        default:
+            throw new Error('Unknown message type: ' + message.messageType);
+    }
 };
 
 exports.parse = (buffer) => {
-  const messageType = buffer.readUInt8(0);
+    const messageType = buffer.readUInt8(0);
 
-  switch (messageType) {
-    case 0x56:
-      return parseVersion(buffer);
-    case 0x45:
-      return parseOrderEntered(buffer);
-    case 0x41:
-      return parseOrderAdded(buffer);
-    case 0x58:
-      return parseOrderCanceled(buffer);
-    case 0x54:
-      return parseTrade(buffer);
-    default:
-      throw new Error('Unknown message type: ' + messageType);
-  }
+    switch (messageType) {
+        case 0x56:
+            return parseVersion(buffer);
+        case 0x45:
+            return parseOrderEntered(buffer);
+        case 0x41:
+            return parseOrderAdded(buffer);
+        case 0x58:
+            return parseOrderCanceled(buffer);
+        case 0x54:
+            return parseTrade(buffer);
+        default:
+            throw new Error('Unknown message type: ' + messageType);
+    }
 };
 
 function formatVersion(message) {
-  const buffer = Buffer.allocUnsafe(5);
+    const buffer = Buffer.allocUnsafe(5);
 
-  buffer.writeUInt8(0x56, 0);
-  buffer.writeUInt32BE(message.version, 1);
+    buffer.writeUInt8(0x56, 0);
+    buffer.writeUInt32BE(message.version, 1);
 
-  return buffer;
+    return buffer;
 }
 
 function parseVersion(buffer) {
-  return {
-    messageType: 'V',
-    version: buffer.readUInt32BE(1),
-  };
+    return {
+        messageType: MessageType.VERSION,
+        version: buffer.readUInt32BE(1),
+    };
 }
 
 function formatOrderEntered(message) {
-  const buffer = Buffer.allocUnsafe(50);
+    const buffer = Buffer.allocUnsafe(50);
 
-  buffer.writeUInt8(0x45, 0);
-  writeUInt64BE(buffer, message.timestamp, 1);
-  writeString(buffer, message.username, 9, 8);
-  writeUInt64BE(buffer, message.orderNumber, 17);
-  writeString(buffer, message.side, 25, 1);
-  writeString(buffer, message.instrument, 26, 8);
-  writeUInt64BE(buffer, message.quantity, 34);
-  writeUInt64BE(buffer, message.price, 42);
+    buffer.writeUInt8(0x45, 0);
+    writeUInt64BE(buffer, message.timestamp, 1);
+    writeString(buffer, message.username, 9, 8);
+    writeUInt64BE(buffer, message.orderNumber, 17);
+    writeString(buffer, message.side, 25, 1);
+    writeString(buffer, message.instrument, 26, 8);
+    writeUInt64BE(buffer, message.quantity, 34);
+    writeUInt64BE(buffer, message.price, 42);
 
-  return buffer;
+    return buffer;
 }
 
 function parseOrderEntered(buffer) {
-  return {
-    messageType: 'E',
-    timestamp: readUInt64BE(buffer, 1),
-    username: readString(buffer, 9, 8),
-    orderNumber: readUInt64BE(buffer, 17),
-    side: readString(buffer, 25, 1),
-    instrument: readString(buffer, 26, 8),
-    quantity: readUInt64BE(buffer, 34),
-    price: readUInt64BE(buffer, 42),
-  };
+    return {
+        messageType: MessageType.ORDER_ENTERED,
+        timestamp: readUInt64BE(buffer, 1),
+        username: readString(buffer, 9, 8),
+        orderNumber: readUInt64BE(buffer, 17),
+        side: readString(buffer, 25, 1),
+        instrument: readString(buffer, 26, 8),
+        quantity: readUInt64BE(buffer, 34),
+        price: readUInt64BE(buffer, 42),
+    };
 }
 
 function formatOrderAdded(message) {
-  const buffer = Buffer.allocUnsafe(17);
+    const buffer = Buffer.allocUnsafe(17);
 
-  buffer.writeUInt8(0x41, 0);
-  writeUInt64BE(buffer, message.timestamp, 1);
-  writeUInt64BE(buffer, message.orderNumber, 9);
+    buffer.writeUInt8(0x41, 0);
+    writeUInt64BE(buffer, message.timestamp, 1);
+    writeUInt64BE(buffer, message.orderNumber, 9);
 
-  return buffer;
+    return buffer;
 }
 
 function parseOrderAdded(buffer) {
-  return {
-    messageType: 'A',
-    timestamp: readUInt64BE(buffer, 1),
-    orderNumber: readUInt64BE(buffer, 9),
-  };
+    return {
+        messageType: MessageType.ORDER_ADDED,
+        timestamp: readUInt64BE(buffer, 1),
+        orderNumber: readUInt64BE(buffer, 9),
+    };
 }
 
 function formatOrderCanceled(message) {
-  const buffer = Buffer.allocUnsafe(25);
+    const buffer = Buffer.allocUnsafe(25);
 
-  buffer.writeUInt8(0x58, 0);
-  writeUInt64BE(buffer, message.timestamp, 1);
-  writeUInt64BE(buffer, message.orderNumber, 9);
-  writeUInt64BE(buffer, message.canceledQuantity, 17);
+    buffer.writeUInt8(0x58, 0);
+    writeUInt64BE(buffer, message.timestamp, 1);
+    writeUInt64BE(buffer, message.orderNumber, 9);
+    writeUInt64BE(buffer, message.canceledQuantity, 17);
 
-  return buffer;
+    return buffer;
 }
 
 function parseOrderCanceled(buffer) {
-  return {
-    messageType: 'X',
-    timestamp: readUInt64BE(buffer, 1),
-    orderNumber: readUInt64BE(buffer, 9),
-    canceledQuantity: readUInt64BE(buffer, 17),
-  };
+    return {
+        messageType: MessageType.ORDER_CANCELED,
+        timestamp: readUInt64BE(buffer, 1),
+        orderNumber: readUInt64BE(buffer, 9),
+        canceledQuantity: readUInt64BE(buffer, 17),
+    };
 }
 
 function formatTrade(message) {
-  const buffer = Buffer.allocUnsafe(37);
+    const buffer = Buffer.allocUnsafe(37);
 
-  buffer.writeUInt8(0x54, 0);
-  writeUInt64BE(buffer, message.timestamp, 1);
-  writeUInt64BE(buffer, message.restingOrderNumber, 9);
-  writeUInt64BE(buffer, message.incomingOrderNumber, 17);
-  writeUInt64BE(buffer, message.quantity, 25);
-  buffer.writeUInt32BE(message.matchNumber, 33);
+    buffer.writeUInt8(0x54, 0);
+    writeUInt64BE(buffer, message.timestamp, 1);
+    writeUInt64BE(buffer, message.restingOrderNumber, 9);
+    writeUInt64BE(buffer, message.incomingOrderNumber, 17);
+    writeUInt64BE(buffer, message.quantity, 25);
+    buffer.writeUInt32BE(message.matchNumber, 33);
 
-  return buffer;
+    return buffer;
 }
 
 function parseTrade(buffer) {
-  return {
-    messageType: 'T',
-    timestamp: readUInt64BE(buffer, 1),
-    restingOrderNumber: readUInt64BE(buffer, 9),
-    incomingOrderNumber: readUInt64BE(buffer, 17),
-    quantity: readUInt64BE(buffer, 25),
-    matchNumber: buffer.readUInt32BE(33),
-  };
+    return {
+        messageType: MessageType.TRADE,
+        timestamp: readUInt64BE(buffer, 1),
+        restingOrderNumber: readUInt64BE(buffer, 9),
+        incomingOrderNumber: readUInt64BE(buffer, 17),
+        quantity: readUInt64BE(buffer, 25),
+        matchNumber: buffer.readUInt32BE(33),
+    };
 }
 
 function writeUInt64BE(buffer, value, offset) {
-  buffer.writeUInt32BE(value / 0x100000000, offset);
-  buffer.writeUInt32BE(value % 0x100000000, offset + 4);
+    buffer.writeUInt32BE(value / 0x100000000, offset);
+    buffer.writeUInt32BE(value % 0x100000000, offset + 4);
 }
 
 function readUInt64BE(buffer, offset) {
-  const high = buffer.readUInt32BE(offset);
-  const low = buffer.readUInt32BE(offset + 4);
+    const high = buffer.readUInt32BE(offset);
+    const low = buffer.readUInt32BE(offset + 4);
 
-  return 0x100000000 * high + low;
+    return 0x100000000 * high + low;
 }
 
 function writeString(buffer, value, offset, length) {
-  const count = buffer.write(value, offset, length, 'ascii');
+    const count = buffer.write(value, offset, length, 'ascii');
 
-  buffer.fill(0x20, offset + count, offset + length);
+    buffer.fill(0x20, offset + count, offset + length);
 }
 
 function readString(buffer, offset, length) {
-  return buffer.toString('ascii', offset, offset + length);
+    return buffer.toString('ascii', offset, offset + length);
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const MessageType = {
-  ORDER_ADDED: "A",
-  ORDER_ENTERED: "E",
-  ORDER_CANCELED: "X",
-  VERSION: "V",
-  TRADE: "T"
+  ORDER_ADDED: 'A',
+  ORDER_ENTERED: 'E',
+  ORDER_CANCELED: 'X',
+  VERSION: 'V',
+  TRADE: 'T'
 };
 
 const Side = {
-  BUY: "B",
-  SELL: "S"
+  BUY: 'B',
+  SELL: 'S'
 };
 
 exports.Side = Side;

--- a/index.js
+++ b/index.js
@@ -1,181 +1,181 @@
 'use strict';
 
 const MessageType = {
-    ORDER_ADDED:  "A",
-    ORDER_ENTERED: "E",
-    ORDER_CANCELED: "X",
-    VERSION: "V",
-    TRADE: "T"
+  ORDER_ADDED: "A",
+  ORDER_ENTERED: "E",
+  ORDER_CANCELED: "X",
+  VERSION: "V",
+  TRADE: "T"
 };
 
 const Side = {
-    BUY: "B",
-    SELL: "S"
+  BUY: "B",
+  SELL: "S"
 };
 
 exports.Side = Side;
 exports.MessageType = MessageType;
 
 exports.format = (message) => {
-    switch (message.messageType) {
-        case MessageType.VERSION:
-            return formatVersion(message);
-        case MessageType.ORDER_ENTERED:
-            return formatOrderEntered(message);
-        case MessageType.ORDER_ADDED:
-            return formatOrderAdded(message);
-        case MessageType.ORDER_CANCELED:
-            return formatOrderCanceled(message);
-        case MessageType.TRADE:
-            return formatTrade(message);
-        default:
-            throw new Error('Unknown message type: ' + message.messageType);
-    }
+  switch (message.messageType) {
+    case MessageType.VERSION:
+      return formatVersion(message);
+    case MessageType.ORDER_ENTERED:
+      return formatOrderEntered(message);
+    case MessageType.ORDER_ADDED:
+      return formatOrderAdded(message);
+    case MessageType.ORDER_CANCELED:
+      return formatOrderCanceled(message);
+    case MessageType.TRADE:
+      return formatTrade(message);
+    default:
+      throw new Error('Unknown message type: ' + message.messageType);
+  }
 };
 
 exports.parse = (buffer) => {
-    const messageType = buffer.readUInt8(0);
+  const messageType = buffer.readUInt8(0);
 
-    switch (messageType) {
-        case 0x56:
-            return parseVersion(buffer);
-        case 0x45:
-            return parseOrderEntered(buffer);
-        case 0x41:
-            return parseOrderAdded(buffer);
-        case 0x58:
-            return parseOrderCanceled(buffer);
-        case 0x54:
-            return parseTrade(buffer);
-        default:
-            throw new Error('Unknown message type: ' + messageType);
-    }
+  switch (messageType) {
+    case 0x56:
+      return parseVersion(buffer);
+    case 0x45:
+      return parseOrderEntered(buffer);
+    case 0x41:
+      return parseOrderAdded(buffer);
+    case 0x58:
+      return parseOrderCanceled(buffer);
+    case 0x54:
+      return parseTrade(buffer);
+    default:
+      throw new Error('Unknown message type: ' + messageType);
+  }
 };
 
 function formatVersion(message) {
-    const buffer = Buffer.allocUnsafe(5);
+  const buffer = Buffer.allocUnsafe(5);
 
-    buffer.writeUInt8(0x56, 0);
-    buffer.writeUInt32BE(message.version, 1);
+  buffer.writeUInt8(0x56, 0);
+  buffer.writeUInt32BE(message.version, 1);
 
-    return buffer;
+  return buffer;
 }
 
 function parseVersion(buffer) {
-    return {
-        messageType: MessageType.VERSION,
-        version: buffer.readUInt32BE(1),
-    };
+  return {
+    messageType: MessageType.VERSION,
+    version: buffer.readUInt32BE(1),
+  };
 }
 
 function formatOrderEntered(message) {
-    const buffer = Buffer.allocUnsafe(50);
+  const buffer = Buffer.allocUnsafe(50);
 
-    buffer.writeUInt8(0x45, 0);
-    writeUInt64BE(buffer, message.timestamp, 1);
-    writeString(buffer, message.username, 9, 8);
-    writeUInt64BE(buffer, message.orderNumber, 17);
-    writeString(buffer, message.side, 25, 1);
-    writeString(buffer, message.instrument, 26, 8);
-    writeUInt64BE(buffer, message.quantity, 34);
-    writeUInt64BE(buffer, message.price, 42);
+  buffer.writeUInt8(0x45, 0);
+  writeUInt64BE(buffer, message.timestamp, 1);
+  writeString(buffer, message.username, 9, 8);
+  writeUInt64BE(buffer, message.orderNumber, 17);
+  writeString(buffer, message.side, 25, 1);
+  writeString(buffer, message.instrument, 26, 8);
+  writeUInt64BE(buffer, message.quantity, 34);
+  writeUInt64BE(buffer, message.price, 42);
 
-    return buffer;
+  return buffer;
 }
 
 function parseOrderEntered(buffer) {
-    return {
-        messageType: MessageType.ORDER_ENTERED,
-        timestamp: readUInt64BE(buffer, 1),
-        username: readString(buffer, 9, 8),
-        orderNumber: readUInt64BE(buffer, 17),
-        side: readString(buffer, 25, 1),
-        instrument: readString(buffer, 26, 8),
-        quantity: readUInt64BE(buffer, 34),
-        price: readUInt64BE(buffer, 42),
-    };
+  return {
+    messageType: MessageType.ORDER_ENTERED,
+    timestamp: readUInt64BE(buffer, 1),
+    username: readString(buffer, 9, 8),
+    orderNumber: readUInt64BE(buffer, 17),
+    side: readString(buffer, 25, 1),
+    instrument: readString(buffer, 26, 8),
+    quantity: readUInt64BE(buffer, 34),
+    price: readUInt64BE(buffer, 42),
+  };
 }
 
 function formatOrderAdded(message) {
-    const buffer = Buffer.allocUnsafe(17);
+  const buffer = Buffer.allocUnsafe(17);
 
-    buffer.writeUInt8(0x41, 0);
-    writeUInt64BE(buffer, message.timestamp, 1);
-    writeUInt64BE(buffer, message.orderNumber, 9);
+  buffer.writeUInt8(0x41, 0);
+  writeUInt64BE(buffer, message.timestamp, 1);
+  writeUInt64BE(buffer, message.orderNumber, 9);
 
-    return buffer;
+  return buffer;
 }
 
 function parseOrderAdded(buffer) {
-    return {
-        messageType: MessageType.ORDER_ADDED,
-        timestamp: readUInt64BE(buffer, 1),
-        orderNumber: readUInt64BE(buffer, 9),
-    };
+  return {
+    messageType: MessageType.ORDER_ADDED,
+    timestamp: readUInt64BE(buffer, 1),
+    orderNumber: readUInt64BE(buffer, 9),
+  };
 }
 
 function formatOrderCanceled(message) {
-    const buffer = Buffer.allocUnsafe(25);
+  const buffer = Buffer.allocUnsafe(25);
 
-    buffer.writeUInt8(0x58, 0);
-    writeUInt64BE(buffer, message.timestamp, 1);
-    writeUInt64BE(buffer, message.orderNumber, 9);
-    writeUInt64BE(buffer, message.canceledQuantity, 17);
+  buffer.writeUInt8(0x58, 0);
+  writeUInt64BE(buffer, message.timestamp, 1);
+  writeUInt64BE(buffer, message.orderNumber, 9);
+  writeUInt64BE(buffer, message.canceledQuantity, 17);
 
-    return buffer;
+  return buffer;
 }
 
 function parseOrderCanceled(buffer) {
-    return {
-        messageType: MessageType.ORDER_CANCELED,
-        timestamp: readUInt64BE(buffer, 1),
-        orderNumber: readUInt64BE(buffer, 9),
-        canceledQuantity: readUInt64BE(buffer, 17),
-    };
+  return {
+    messageType: MessageType.ORDER_CANCELED,
+    timestamp: readUInt64BE(buffer, 1),
+    orderNumber: readUInt64BE(buffer, 9),
+    canceledQuantity: readUInt64BE(buffer, 17),
+  };
 }
 
 function formatTrade(message) {
-    const buffer = Buffer.allocUnsafe(37);
+  const buffer = Buffer.allocUnsafe(37);
 
-    buffer.writeUInt8(0x54, 0);
-    writeUInt64BE(buffer, message.timestamp, 1);
-    writeUInt64BE(buffer, message.restingOrderNumber, 9);
-    writeUInt64BE(buffer, message.incomingOrderNumber, 17);
-    writeUInt64BE(buffer, message.quantity, 25);
-    buffer.writeUInt32BE(message.matchNumber, 33);
+  buffer.writeUInt8(0x54, 0);
+  writeUInt64BE(buffer, message.timestamp, 1);
+  writeUInt64BE(buffer, message.restingOrderNumber, 9);
+  writeUInt64BE(buffer, message.incomingOrderNumber, 17);
+  writeUInt64BE(buffer, message.quantity, 25);
+  buffer.writeUInt32BE(message.matchNumber, 33);
 
-    return buffer;
+  return buffer;
 }
 
 function parseTrade(buffer) {
-    return {
-        messageType: MessageType.TRADE,
-        timestamp: readUInt64BE(buffer, 1),
-        restingOrderNumber: readUInt64BE(buffer, 9),
-        incomingOrderNumber: readUInt64BE(buffer, 17),
-        quantity: readUInt64BE(buffer, 25),
-        matchNumber: buffer.readUInt32BE(33),
-    };
+  return {
+    messageType: MessageType.TRADE,
+    timestamp: readUInt64BE(buffer, 1),
+    restingOrderNumber: readUInt64BE(buffer, 9),
+    incomingOrderNumber: readUInt64BE(buffer, 17),
+    quantity: readUInt64BE(buffer, 25),
+    matchNumber: buffer.readUInt32BE(33),
+  };
 }
 
 function writeUInt64BE(buffer, value, offset) {
-    buffer.writeUInt32BE(value / 0x100000000, offset);
-    buffer.writeUInt32BE(value % 0x100000000, offset + 4);
+  buffer.writeUInt32BE(value / 0x100000000, offset);
+  buffer.writeUInt32BE(value % 0x100000000, offset + 4);
 }
 
 function readUInt64BE(buffer, offset) {
-    const high = buffer.readUInt32BE(offset);
-    const low = buffer.readUInt32BE(offset + 4);
+  const high = buffer.readUInt32BE(offset);
+  const low = buffer.readUInt32BE(offset + 4);
 
-    return 0x100000000 * high + low;
+  return 0x100000000 * high + low;
 }
 
 function writeString(buffer, value, offset, length) {
-    const count = buffer.write(value, offset, length, 'ascii');
+  const count = buffer.write(value, offset, length, 'ascii');
 
-    buffer.fill(0x20, offset + count, offset + length);
+  buffer.fill(0x20, offset + count, offset + length);
 }
 
 function readString(buffer, offset, length) {
-    return buffer.toString('ascii', offset, offset + length);
+  return buffer.toString('ascii', offset, offset + length);
 }


### PR DESCRIPTION
Added "enums in index.js and full types (interfaces and enums).

The usage for this version would be like this:
```typescript
import * as PMR from "parity-pmr";

const orderEntered : PMR.OrderEntered = {
    messageType: PMR.MessageType.ORDER_ENTERED ,
    timestamp: 123456,
    username: "username",
    orderNumber: 123456,
    side: PMR.Side.BUY,
    instrument: "ETH-BTC",
    quantity: 2,
    price: 30,
};

const formattedMessage: Buffer = PMR.format(orderEntered);

const parsedMessage = PMR.parse(formattedMessage);

const oe: PMR.OrderEntered = <PMR.OrderEntered>parsedMessage;
```

I was unable to run tests.